### PR TITLE
CSS modulesスタイルシート削除を防ぐカスタムフックを作成  #8

### DIFF
--- a/lilly/src/hooks/useNextCssRemovalPrevention.tsx
+++ b/lilly/src/hooks/useNextCssRemovalPrevention.tsx
@@ -1,0 +1,63 @@
+import { useEffect } from 'react'
+
+export const useNextCssRemovalPrevention = () => {
+  useEffect(() => {
+    // Remove data-n-p attribute from all link nodes.
+    // This prevents Next.js from removing server-rendered stylesheets.
+    document.querySelectorAll('head > link[data-n-p]').forEach((linkNode) => {
+      linkNode.removeAttribute('data-n-p')
+    })
+
+    const mutationHandler = (mutations: MutationRecord[]) => {
+      mutations.forEach(({ target, addedNodes }: MutationRecord) => {
+        if (target.nodeName === 'HEAD') {
+          // Add data-n-href-perm attribute to all style nodes with attribute data-n-href,
+          // and remove data-n-href and media attributes from those nodes.
+          // This prevents Next.js from removing or disabling dynamic stylesheets.
+          addedNodes.forEach((node) => {
+            const el = node as Element
+            if (el.nodeName === 'STYLE' && el.hasAttribute('data-n-href')) {
+              const href = el.getAttribute('data-n-href')
+              if (href) {
+                el.setAttribute('data-n-href-perm', href)
+                el.removeAttribute('data-n-href')
+                el.removeAttribute('media')
+              }
+            }
+          })
+
+          // Remove all stylesheets that we don't need anymore
+          // (all except the two that were most recently added).
+          const styleNodes = document.querySelectorAll(
+            'head > style[data-n-href-perm]'
+          )
+          const requiredHrefs = new Set<string>()
+          for (let i = styleNodes.length - 1; i >= 0; i--) {
+            const el = styleNodes[i]
+            if (requiredHrefs.size < 2) {
+              const href = el.getAttribute('data-n-href-perm')
+              if (href) {
+                if (requiredHrefs.has(href)) {
+                  el.parentNode!.removeChild(el)
+                } else {
+                  requiredHrefs.add(href)
+                }
+              }
+            } else {
+              el.parentNode!.removeChild(el)
+            }
+          }
+        }
+      })
+    }
+
+    // Observe changes to the head element and its descendents.
+    const observer = new MutationObserver(mutationHandler)
+    observer.observe(document.head, { childList: true, subtree: true })
+
+    return () => {
+      // Disconnect the observer when the component unmounts.
+      observer.disconnect()
+    }
+  }, [])
+}

--- a/lilly/src/pages/_app.tsx
+++ b/lilly/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from 'next/app'
 import React from 'react'
 import { AnimatePresence } from 'framer-motion'
+import { useNextCssRemovalPrevention } from '@/hooks/useNextCssRemovalPrevention'
 import '@/styles/globals.scss'
 import 'zenn-content-css'
 import 'tocbot/dist/tocbot.css'
 
 export default function App({ Component, pageProps, router }: AppProps) {
+  useNextCssRemovalPrevention()
+
   return (
     <AnimatePresence
       initial={false}


### PR DESCRIPTION
why
- ルート変更時に CSS modulesのスタイリングが削除されるのが早すぎる

what
- スタイルシート削除を防ぐカスタムフックを作成
- すべてのページに適用